### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/HollyDickson0676/6640387a-68e4-48bd-b7eb-f5e5720d27c7/567b3b75-5db4-40a9-87b8-55277209c799/_apis/work/boardbadge/2e80b6bd-8a17-4a4f-8b94-99e71a44d570)](https://dev.azure.com/HollyDickson0676/6640387a-68e4-48bd-b7eb-f5e5720d27c7/_boards/board/t/567b3b75-5db4-40a9-87b8-55277209c799/Microsoft.RequirementCategory)
 # Primerrepositorio


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#180](https://dev.azure.com/HollyDickson0676/6640387a-68e4-48bd-b7eb-f5e5720d27c7/_workitems/edit/180). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.